### PR TITLE
Fix unescaped ampersand in fonts link

### DIFF
--- a/sharon_rousseau_cv_website.html
+++ b/sharon_rousseau_cv_website.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sharon Rousseau | Operations Professional</title>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500;700&amp;display=swap" rel="stylesheet">
   <style>
     body {
       font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
## Summary
- escape the `&` in the Google Fonts URL to make valid HTML

## Testing
- `tidy -errors sharon_rousseau_cv_website.html`

------
https://chatgpt.com/codex/tasks/task_e_6864077ddf508331827979bb86492ddd