### PR TITLE
Add short CV download button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1019,6 +1019,56 @@
         margin: 0;
       }
 
+      .short-cv-section {
+        text-align: center;
+        margin: 2rem 0;
+      }
+
+      .short-cv-btn {
+        background: var(--accent-gradient);
+        color: #fff;
+        border: none;
+        padding: 1rem 2.5rem;
+        border-radius: 25px;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
+        position: relative;
+        overflow: hidden;
+        text-decoration: none;
+        transition: all 0.3s ease;
+        display: inline-block;
+      }
+
+      .short-cv-btn::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: -100%;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(
+          90deg,
+          transparent,
+          rgba(255, 255, 255, 0.3),
+          transparent
+        );
+        transition: left 0.5s;
+      }
+
+      .short-cv-btn:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 12px 35px rgba(0, 0, 0, 0.4);
+        filter: brightness(1.1);
+      }
+
+      .short-cv-btn:hover::before {
+        left: 100%;
+      }
+
       @media (max-width: 1024px) {
         .sidebar-nav {
           display: none;
@@ -2401,6 +2451,12 @@
         </div>
       </section>
     </main>
+
+    <div class="short-cv-section">
+      <a href="Sharon_Rousseau_CV_2025.pdf" download class="short-cv-btn"
+        >Need the Short Version?</a
+      >
+    </div>
 
     <script>
       function toggleJobDetails(button) {


### PR DESCRIPTION
## Summary
- add styles for new short CV download button
- add "Need the Short Version?" link under main content

## Testing
- `html5validator index.html` *(fails: CSS backdrop-filter property doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68651b1dcc70833188501718c115fa71